### PR TITLE
Remove the photon veto from the skim selections.

### DIFF
--- a/input/input_selection.txt
+++ b/input/input_selection.txt
@@ -24,9 +24,6 @@ veto
 	IsoMuonTrackVeto
 	IsoElectronTrackVeto
 	IsoPionTrackVeto
-vetop
-	veto
-	Photon	s:name[PhotonVeto]	b:veto[1]
 ra2bin
 	RA2Bin	in:options[input/input_RA2bin_options.txt]	b:forceadd[1]	b:tightfast[1]
 #	PileupAcc	s:name[PileupAccAfter]	i:cut[20]	i:xnum[101]	d:xmin[-0.5]	d:xmax[100.5]	s:depname[PileupAccBefore]
@@ -66,7 +63,7 @@ dphiinv
 signalUnblind
 	common
 	baseline
-	vetop
+	veto
 	dphi
 	evtclean
 	ra2bin
@@ -77,7 +74,7 @@ signal
 signalSideband
 	common
 	baselinesb
-	vetop
+	veto
 	dphi
 	evtclean
 	ra2bin
@@ -87,7 +84,7 @@ signalTight
 	NJet	i:njet[3]
 	HT	d:min[300]
 	MHT	d:min[300]
-	vetop
+	veto
 	dphi
 	evtclean
 	ra2bin
@@ -97,7 +94,7 @@ signalTight250
 	NJet	i:njet[3]
 	HT	d:min[300]
 	MHT	d:min[250]
-	vetop
+	veto
 	dphi
 	evtclean
 	ra2bin
@@ -107,14 +104,14 @@ signal2015
 	NJet	i:njet[4]
 	HT	d:min[500]
 	MHT	d:min[200]
-	vetop
+	veto
 	dphi
 	evtclean
 	ra2bin
 LDP
 	common
 	baseline
-	vetop
+	veto
 	dphiinv
 	evtclean
 	ra2bin
@@ -123,7 +120,6 @@ SLm
 	baseline
 	Muon
 	ElectronVeto
-	Photon	b:veto[1]
 	dphi
 	evtclean
 	ra2bin
@@ -132,7 +128,6 @@ SLe
 	baseline
 	MuonVeto
 	Electron
-	Photon	b:veto[1]
 	dphi
 	evtclean
 	ra2bin
@@ -141,7 +136,6 @@ SLmLDP
 	baseline
 	Muon
 	ElectronVeto
-	Photon	b:veto[1]
 	dphiinv
 	evtclean
 	ra2bin
@@ -150,7 +144,6 @@ SLeLDP
 	baseline
 	MuonVeto
 	Electron
-	Photon	b:veto[1]
 	dphiinv
 	evtclean
 	ra2bin
@@ -177,7 +170,6 @@ DYm
 	ElectronVeto
 	IsoElectronTrackVeto
 	IsoPionTrackVeto
-	Photon	b:veto[1]
 	dphi
 	evtclean
 	ra2bin
@@ -188,7 +180,6 @@ DYe
 	DiElectron
 	IsoMuonTrackVeto
 	IsoPionTrackVeto
-	Photon	b:veto[1]
 	dphi
 	evtclean
 	ra2bin
@@ -215,7 +206,6 @@ DYmLDP
 	ElectronVeto
 	IsoElectronTrackVeto
 	IsoPionTrackVeto
-	Photon	b:veto[1]
 	dphiinv
 	evtclean
 	ra2bin
@@ -226,7 +216,6 @@ DYeLDP
 	DiElectron
 	IsoMuonTrackVeto
 	IsoPionTrackVeto
-	Photon	b:veto[1]
 	dphiinv
 	evtclean
 	ra2bin


### PR DESCRIPTION
Remove the photon veto used for the skims. It was decided that this veto shouldn't be used for the HH+MET analysis.